### PR TITLE
Fixing issue with unkown credentials in fork - (Task #10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,8 @@ after_failure:
   # then try to deploy the screenshots from 
   # SWTBot to see what happened 
   # ----------------------------------------
-  - mkdir -p -m 700 /tmp/.sourceforge_ssh
-  - openssl aes-256-cbc -K $encrypted_9c25c12f834a_key -iv $encrypted_9c25c12f834a_iv -in id_ed25519.enc -out /tmp/.sourceforge_ssh/id_ed25519 -d
-  - chmod 600 /tmp/.sourceforge_ssh/id_ed25519
-  - ssh-add /tmp/.sourceforge_ssh/id_ed25519
-  - ls -l $TRAVIS_BUILD_DIR/swtbot/
-  - rsync -e ssh -avP $TRAVIS_BUILD_DIR/swtbot/  dlrscmns@frs.sourceforge.net:/home/frs/project/virtualsatellite/VirtualSatellite4-Core/swtbot/
-
+  - ./bash/upload_swt_bot_screenshots.sh $encrypted_9c25c12f834a_key $encrypted_9c25c12f834a_iv 
+  
 jobs:
   include:
    

--- a/bash/upload_swt_bot_screenshots.sh
+++ b/bash/upload_swt_bot_screenshots.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "[Info] ------------------------------------"
+echo "[Info] Upload SWT BoT Screenshots"
+echo "[Info] ------------------------------------"
+echo "[Info] "
+
+if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+	echo "[Info] Secrets found preparing upload."
+	mkdir -p -m 700 /tmp/.sourceforge_ssh
+	openssl aes-256-cbc -K $1 -iv $2 -in id_ed25519.enc -out /tmp/.sourceforge_ssh/id_ed25519 -d
+	chmod 600 /tmp/.sourceforge_ssh/id_ed25519
+	ssh-add /tmp/.sourceforge_ssh/id_ed25519
+	ls -l $TRAVIS_BUILD_DIR/swtbot/
+	echo "[Info] Sending screenshots to sourceforge"
+	rsync -e ssh -avP $TRAVIS_BUILD_DIR/swtbot/  dlrscmns@frs.sourceforge.net:/home/frs/project/virtualsatellite/VirtualSatellite4-Core/swtbot/
+else
+	echo "[Info] No Secrets, won't upload."
+fi
+
+echo "[Info] ------------------------------------"
+echo "[Info] Done"
+echo "[Info] ------------------------------------"
+    


### PR DESCRIPTION
- when builds are failing they send debug info to sourceforge. A fork
cant do that ebcause travis does not provide the secrets. teherefore we
have to skip the upload.

---
Task #10: Provide Contribution Capabilities